### PR TITLE
identityagent: add GetClaimByHi & GetFullMT for one identity

### DIFF
--- a/merkletree/merkletree.go
+++ b/merkletree/merkletree.go
@@ -180,9 +180,12 @@ type MerkleTree struct {
 	writable bool
 }
 
+var PREFIX_MERKLETREE = []byte("merkletree")
+
 // NewMerkleTree generates a new Merkle Tree
 func NewMerkleTree(storage db.Storage, maxLevels int) (*MerkleTree, error) {
-	mt := MerkleTree{storage: storage, maxLevels: maxLevels, writable: true}
+	mtSto := storage.WithPrefix(PREFIX_MERKLETREE)
+	mt := MerkleTree{storage: mtSto, maxLevels: maxLevels, writable: true}
 	_, gettedRoot, err := mt.dbGet(rootNodeValue)
 	if err != nil {
 		tx, err := mt.storage.NewTx()


### PR DESCRIPTION
closes #156 , closes #158 
when issues #167 and #169 are done, will be able to update this with the part of the proof from the Relay (RootUpdater)