### PR TITLE
Add a method to allow a custom prefix to the new merkletree method

### DIFF
--- a/merkletree/merkletree.go
+++ b/merkletree/merkletree.go
@@ -201,7 +201,12 @@ var PREFIX_MERKLETREE = []byte("merkletree")
 
 // NewMerkleTree generates a new Merkle Tree
 func NewMerkleTree(storage db.Storage, maxLevels int) (*MerkleTree, error) {
-	mtSto := storage.WithPrefix(PREFIX_MERKLETREE)
+	return NewMerkleTreeWithPrefix(storage, maxLevels, PREFIX_MERKLETREE)
+}
+
+// NewMerkleTreeWithPrefix generates a new merkle tree with the given prefix
+func NewMerkleTreeWithPrefix(storage db.Storage, maxLevels int, prefix []byte) (*MerkleTree, error) {
+	mtSto := storage.WithPrefix(prefix)
 	mt := MerkleTree{storage: mtSto, maxLevels: maxLevels, writable: true}
 	_, gettedRoot, err := mt.dbGet(rootNodeValue)
 	if err != nil {

--- a/merkletree/merkletree_test.go
+++ b/merkletree/merkletree_test.go
@@ -34,10 +34,23 @@ func newTestingMerkle(f Fatalable, numLevels int) *MerkleTree {
 	return mt
 }
 
+func newTestingMerkleWithPrefix(f Fatalable, numLevels int) *MerkleTree {
+	mt, err := NewMerkleTreeWithPrefix(db.NewMemoryStorage(), numLevels, []byte("testingprefix"))
+	if err != nil {
+		f.Fatal(err)
+		return nil
+	}
+	return mt
+}
+
 func TestNewMT(t *testing.T) {
 	//create a new MT
 	mt := newTestingMerkle(t, 140)
 	defer mt.Storage().Close()
+	assert.Equal(t,
+		"0x0000000000000000000000000000000000000000000000000000000000000000",
+		mt.RootKey().Hex())
+	mt = newTestingMerkleWithPrefix(t, 140)
 	assert.Equal(t,
 		"0x0000000000000000000000000000000000000000000000000000000000000000",
 		mt.RootKey().Hex())


### PR DESCRIPTION
Hi, I'm currently working on an [identity hub implementation](https://github.com/decentralized-identity/identity-hub/blob/master/explainer.md) and we are using the merkle tree implemented here.  Currently when you create a new merkle tree it always appends the prefix "merkletree" to the passed-in store.  This pr adds a second method that allows the consumer of this package to add a custom prefix to the tree instead.

Our reasoning for this is that we are using postgres as our store instead of leveldb.  It's a bit cleaner for us to just prefix trees with the identity they belong to without adding merkletree to that value.

If there's anything i need to change to improve this let me know.

Thanks!