### PR TITLE
resolves issue #208 by removing the merkletree prefix from NewMerkleTree

### DIFF
--- a/merkletree/merkletree.go
+++ b/merkletree/merkletree.go
@@ -197,12 +197,9 @@ type MerkleTree struct {
 	writable bool
 }
 
-var PREFIX_MERKLETREE = []byte("merkletree")
-
 // NewMerkleTree generates a new Merkle Tree
 func NewMerkleTree(storage db.Storage, maxLevels int) (*MerkleTree, error) {
-	mtSto := storage.WithPrefix(PREFIX_MERKLETREE)
-	mt := MerkleTree{storage: mtSto, maxLevels: maxLevels, writable: true}
+	mt := MerkleTree{storage: storage, maxLevels: maxLevels, writable: true}
 	_, gettedRoot, err := mt.dbGet(rootNodeValue)
 	if err != nil {
 		tx, err := mt.storage.NewTx()


### PR DESCRIPTION
@ed255 removed the merkletree prefix so the tree uses whatever prefix the store already has as specified issue #208.  Let me know if theres anything else. 