### PR TITLE
Don't use pointers for Marshalers

### DIFF
--- a/core/claims/claim.go
+++ b/core/claims/claim.go
@@ -182,7 +182,7 @@ func byte2bool(b byte) bool {
 }
 
 // Marshal the ClaimHeader into an entry
-func (c *ClaimHeader) Marshal(e *merkletree.Entry) {
+func (c ClaimHeader) Marshal(e *merkletree.Entry) {
 	index := e.Index()
 	copy(index[0][:ClaimTypeLen], c.Type[:])
 	flags0 := &index[0][ClaimTypeLen]
@@ -249,7 +249,7 @@ func (m *Metadata) Type() ClaimType {
 }
 
 // Marshal the Metadata into an entry
-func (m *Metadata) Marshal(e *merkletree.Entry) {
+func (m Metadata) Marshal(e *merkletree.Entry) {
 	m.header.Marshal(e)
 	index := e.Index()
 	value := e.Value()

--- a/crypto/ecdsa_public_key.go
+++ b/crypto/ecdsa_public_key.go
@@ -14,7 +14,7 @@ type PublicKey struct {
 }
 
 // MarshalJSON serializes the public key as a hex string.
-func (pk *PublicKey) MarshalJSON() ([]byte, error) {
+func (pk PublicKey) MarshalJSON() ([]byte, error) {
 	return json.Marshal(common3.HexEncode(crypto.CompressPubkey(&pk.PublicKey)))
 }
 

--- a/crypto/signatures.go
+++ b/crypto/signatures.go
@@ -22,7 +22,7 @@ func (s *Signature) UnmarshalJSON(bs []byte) error {
 }
 
 // MarshalJSON serializes a signature as a hex string.
-func (s *Signature) MarshalJSON() ([]byte, error) {
+func (s Signature) MarshalJSON() ([]byte, error) {
 	return json.Marshal(common3.HexEncode(s[:]))
 }
 
@@ -36,7 +36,7 @@ func (s *SignatureEthMsg) UnmarshalJSON(bs []byte) error {
 }
 
 // MarshalJSON serializes a signature as a hex string.
-func (s *SignatureEthMsg) MarshalJSON() ([]byte, error) {
+func (s SignatureEthMsg) MarshalJSON() ([]byte, error) {
 	return json.Marshal(common3.HexEncode(s[:]))
 }
 

--- a/merkletree/merkletree.go
+++ b/merkletree/merkletree.go
@@ -71,7 +71,7 @@ func (d1 *Data) Equal(d2 *Data) bool {
 		bytes.Equal(d1[2][:], d2[2][:]) && bytes.Equal(d1[3][:], d2[3][:])
 }
 
-func (d *Data) MarshalText() ([]byte, error) {
+func (d Data) MarshalText() ([]byte, error) {
 	dataBytes := d.Bytes()
 	return []byte(common3.HexEncode(dataBytes[:])), nil
 }
@@ -171,7 +171,7 @@ func (e1 *Entry) Equal(e2 *Entry) bool {
 	return e1.Data.Equal(&e2.Data)
 }
 
-func (e *Entry) MarshalText() ([]byte, error) {
+func (e Entry) MarshalText() ([]byte, error) {
 	return []byte(common3.HexEncode(e.Bytes())), nil
 }
 
@@ -763,7 +763,7 @@ func (p *Proof) Bytes() []byte {
 	return bs
 }
 
-func (p *Proof) MarshalJSON() ([]byte, error) {
+func (p Proof) MarshalJSON() ([]byte, error) {
 	return json.Marshal(common3.HexEncode(p.Bytes()))
 }
 

--- a/merkletree/utils.go
+++ b/merkletree/utils.go
@@ -33,7 +33,7 @@ func (h Hash) Bytes() []byte {
 	return h[:]
 }
 
-func (h *Hash) MarshalText() ([]byte, error) {
+func (h Hash) MarshalText() ([]byte, error) {
 	return []byte(common3.HexEncode(h.Bytes())), nil
 }
 


### PR DESCRIPTION
I was having troubles marshaling values into a database and found out that marshalers are more commonly defined on the type and not on the reference to the type, so I changed all the marshalers so that they play nicely with other libraries.