### PR TITLE
Add a local implementation of idenpubonchain and idenpuboffchain

### DIFF
--- a/components/idenpuboffchain/idenpuboffchain.go
+++ b/components/idenpuboffchain/idenpuboffchain.go
@@ -20,7 +20,7 @@ type IdenPubOffChainReader interface {
 
 // IdenPubOffChainWriter is a interface to write the off chain public state of an identity.
 type IdenPubOffChainWriter interface {
-	Publish(publicData *PublicData) error
+	Publish(id *core.ID, publicData *PublicData) error
 	Url() string
 }
 

--- a/components/idenpuboffchain/local/local.go
+++ b/components/idenpuboffchain/local/local.go
@@ -1,0 +1,68 @@
+package local
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/iden3/go-iden3-core/components/idenpuboffchain"
+	"github.com/iden3/go-iden3-core/core"
+	"github.com/iden3/go-iden3-core/merkletree"
+)
+
+type IdenPubOffChainIden struct {
+	datas map[merkletree.Hash]*idenpuboffchain.PublicData
+	last  *merkletree.Hash
+}
+
+type IdenPubOffChain struct {
+	rw    sync.RWMutex
+	idens map[core.ID]*IdenPubOffChainIden
+	url   string
+}
+
+func NewIdenPubOffChain(url string) *IdenPubOffChain {
+	return &IdenPubOffChain{
+		idens: make(map[core.ID]*IdenPubOffChainIden),
+		url:   url,
+	}
+}
+
+func (ip *IdenPubOffChain) GetPublicData(idenPubUrl string, id *core.ID, idenState *merkletree.Hash) (*idenpuboffchain.PublicData, error) {
+	if ip.url != idenPubUrl {
+		return nil, fmt.Errorf("Bad URL")
+	}
+	ip.rw.RLock()
+	defer ip.rw.RUnlock()
+	iden, ok := ip.idens[*id]
+	if !ok {
+		return nil, fmt.Errorf("ID not found")
+	}
+	if idenState == nil {
+		idenState = iden.last
+	}
+	data, ok := iden.datas[*idenState]
+	if !ok {
+		return nil, fmt.Errorf("idenState not found")
+	}
+	return data, nil
+}
+
+func (ip *IdenPubOffChain) Url() string {
+	return ip.url
+}
+
+func (ip *IdenPubOffChain) Publish(id *core.ID, publicData *idenpuboffchain.PublicData) error {
+	ip.rw.Lock()
+	defer ip.rw.Unlock()
+	iden, ok := ip.idens[*id]
+	if !ok {
+		iden = &IdenPubOffChainIden{
+			datas: make(map[merkletree.Hash]*idenpuboffchain.PublicData),
+			last:  nil,
+		}
+		ip.idens[*id] = iden
+	}
+	iden.datas[*publicData.IdenState] = publicData
+	iden.last = publicData.IdenState
+	return nil
+}

--- a/components/idenpuboffchain/writerhttp/writerhttp.go
+++ b/components/idenpuboffchain/writerhttp/writerhttp.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/iden3/go-iden3-core/components/idenpuboffchain"
+	"github.com/iden3/go-iden3-core/core"
 	"github.com/iden3/go-iden3-core/db"
 	"github.com/iden3/go-iden3-core/merkletree"
 )
@@ -81,7 +82,7 @@ func (i *IdenPubOffChainWriteHttp) Url() string {
 }
 
 // Publish publishes the RootsTree and RevocationsTree to the configured way of publishing
-func (i *IdenPubOffChainWriteHttp) Publish(publicData *idenpuboffchain.PublicData) error {
+func (i *IdenPubOffChainWriteHttp) Publish(id *core.ID, publicData *idenpuboffchain.PublicData) error {
 	// RootsTree
 	w := bytes.NewBufferString("")
 	err := publicData.RootsTree.DumpTree(w, publicData.RootsTreeRoot)

--- a/components/idenpuboffchain/writerhttp/writerhttp_test.go
+++ b/components/idenpuboffchain/writerhttp/writerhttp_test.go
@@ -60,7 +60,7 @@ func TestHttpPublicGetPublicData(t *testing.T) {
 		RootsTree:           rotMt,
 	}
 
-	err = idenPubOffChainWriteHttp.Publish(&publicData)
+	err = idenPubOffChainWriteHttp.Publish(&core.ID{}, &publicData)
 	assert.Nil(t, err)
 
 	pubDataBlobs, err := idenPubOffChainWriteHttp.GetPublicData(nil)

--- a/components/idenpuboffchain/writermock/writermock.go
+++ b/components/idenpuboffchain/writermock/writermock.go
@@ -2,6 +2,7 @@ package writermock
 
 import (
 	"github.com/iden3/go-iden3-core/components/idenpuboffchain"
+	"github.com/iden3/go-iden3-core/core"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -13,8 +14,8 @@ func New() *IdenPubOffChainWriteMock {
 	return &IdenPubOffChainWriteMock{}
 }
 
-func (i *IdenPubOffChainWriteMock) Publish(publicData *idenpuboffchain.PublicData) error {
-	args := i.Called(publicData)
+func (i *IdenPubOffChainWriteMock) Publish(id *core.ID, publicData *idenpuboffchain.PublicData) error {
+	args := i.Called(id, publicData)
 	return args.Error(0)
 }
 

--- a/components/idenpubonchain/idenpubonchain.go
+++ b/components/idenpubonchain/idenpubonchain.go
@@ -28,8 +28,11 @@ type IdenPubOnChainer interface {
 	GetState(id *core.ID) (*proof.IdenStateData, error)
 	GetStateByBlock(id *core.ID, blockN uint64) (*proof.IdenStateData, error)
 	GetStateByTime(id *core.ID, blockTimestamp int64) (*proof.IdenStateData, error)
-	SetState(id *core.ID, newState *merkletree.Hash, kOpProof []byte, stateTransitionProof []byte, signature *babyjub.SignatureComp) (*types.Transaction, error)
-	InitState(id *core.ID, genesisState *merkletree.Hash, newState *merkletree.Hash, kOpProof []byte, stateTransitionProof []byte, signature *babyjub.SignatureComp) (*types.Transaction, error)
+	SetState(id *core.ID, newState *merkletree.Hash, kOpProof []byte,
+		stateTransitionProof []byte, signature *babyjub.SignatureComp) (*types.Transaction, error)
+	InitState(id *core.ID, genesisState *merkletree.Hash,
+		newState *merkletree.Hash, kOpProof []byte, stateTransitionProof []byte,
+		signature *babyjub.SignatureComp) (*types.Transaction, error)
 	// VerifyProofClaim(pc *proof.ProofClaim) (bool, error)
 }
 
@@ -159,7 +162,8 @@ func splitSignature(signature *babyjub.SignatureComp) (sigR8 [32]byte, sigS [32]
 }
 
 // SetState updates the Identity State of the given ID in the IdenStates Smart Contract.
-func (ip *IdenPubOnChain) SetState(id *core.ID, newState *merkletree.Hash, kOpProof []byte, stateTransitionProof []byte, signature *babyjub.SignatureComp) (*types.Transaction, error) {
+func (ip *IdenPubOnChain) SetState(id *core.ID, newState *merkletree.Hash, kOpProof []byte,
+	stateTransitionProof []byte, signature *babyjub.SignatureComp) (*types.Transaction, error) {
 	if tx, err := ip.client.CallAuth(
 		func(c *ethclient.Client, auth *bind.TransactOpts) (*types.Transaction, error) {
 			idenStates, err := contracts.NewState(ip.addresses.IdenStates, c)
@@ -177,7 +181,9 @@ func (ip *IdenPubOnChain) SetState(id *core.ID, newState *merkletree.Hash, kOpPr
 }
 
 // InitState initializes the first Identity State of the given ID in the IdenStates Smart Contract.
-func (ip *IdenPubOnChain) InitState(id *core.ID, genesisState *merkletree.Hash, newState *merkletree.Hash, kOpProof []byte, stateTransitionProof []byte, signature *babyjub.SignatureComp) (*types.Transaction, error) {
+func (ip *IdenPubOnChain) InitState(id *core.ID, genesisState *merkletree.Hash,
+	newState *merkletree.Hash, kOpProof []byte, stateTransitionProof []byte,
+	signature *babyjub.SignatureComp) (*types.Transaction, error) {
 	if tx, err := ip.client.CallAuth(
 		func(c *ethclient.Client, auth *bind.TransactOpts) (*types.Transaction, error) {
 			idenStates, err := contracts.NewState(ip.addresses.IdenStates, c)
@@ -185,7 +191,8 @@ func (ip *IdenPubOnChain) InitState(id *core.ID, genesisState *merkletree.Hash, 
 				return nil, err
 			}
 			sigR8, sigS := splitSignature(signature)
-			return idenStates.InitState(auth, *newState, *genesisState, *id, kOpProof, stateTransitionProof, sigR8, sigS)
+			return idenStates.InitState(auth, *newState, *genesisState, *id, kOpProof,
+				stateTransitionProof, sigR8, sigS)
 		},
 	); err != nil {
 		return nil, fmt.Errorf("Failed initalizating identity state in the Smart Contract (initState): %w", err)

--- a/components/idenpubonchain/local/local.go
+++ b/components/idenpubonchain/local/local.go
@@ -1,0 +1,164 @@
+package local
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/iden3/go-iden3-core/components/idenpubonchain"
+	"github.com/iden3/go-iden3-core/core"
+	"github.com/iden3/go-iden3-core/core/proof"
+	"github.com/iden3/go-iden3-core/merkletree"
+	"github.com/iden3/go-iden3-crypto/babyjub"
+)
+
+type IdenStateHistory struct {
+	IdenStates []*proof.IdenStateData
+	ByTime     map[int64]*proof.IdenStateData
+	ByBlock    map[uint64]*proof.IdenStateData
+}
+
+func NewIdenStateHistory() *IdenStateHistory {
+	return &IdenStateHistory{
+		IdenStates: make([]*proof.IdenStateData, 0),
+		ByTime:     make(map[int64]*proof.IdenStateData),
+		ByBlock:    make(map[uint64]*proof.IdenStateData),
+	}
+}
+
+func (h *IdenStateHistory) Add(idenStateData *proof.IdenStateData) {
+	h.IdenStates = append(h.IdenStates, idenStateData)
+	h.ByTime[idenStateData.BlockTs] = idenStateData
+	h.ByBlock[idenStateData.BlockN] = idenStateData
+}
+
+type IdIdenStateData struct {
+	Id            *core.ID
+	IdenStateData *proof.IdenStateData
+}
+
+// IdenPubOnChain is an implementation of the IdenPubOnnChainer that instead of
+// interacting with the blockchain has a local copy of the identities states.
+// All writes (Init and Set) are set to a pending queue, and written into the
+// internal state once the Sync function is called.
+type IdenPubOnChain struct {
+	rw             sync.RWMutex
+	idenStatesData map[core.ID]*IdenStateHistory
+	pendingInit    []*IdIdenStateData
+	pendingSet     []*IdIdenStateData
+	timeNow        func() time.Time
+	blockNow       func() uint64
+}
+
+// New creates a new IdenPubOnChain
+func New(timeNow func() time.Time, blockNow func() uint64) *IdenPubOnChain {
+	return &IdenPubOnChain{
+		idenStatesData: make(map[core.ID]*IdenStateHistory),
+		pendingInit:    make([]*IdIdenStateData, 0),
+		pendingSet:     make([]*IdIdenStateData, 0),
+		timeNow:        timeNow,
+		blockNow:       blockNow,
+	}
+}
+
+// Sync all the pending writes to the local state.
+func (ip *IdenPubOnChain) Sync() {
+	for _, idIdenStateData := range ip.pendingInit {
+		idenStatesData := NewIdenStateHistory()
+		idenStatesData.Add(idIdenStateData.IdenStateData)
+		ip.idenStatesData[*idIdenStateData.Id] = idenStatesData
+	}
+	for _, idIdenStateData := range ip.pendingSet {
+		ip.idenStatesData[*idIdenStateData.Id].Add(idIdenStateData.IdenStateData)
+	}
+	ip.pendingInit = make([]*IdIdenStateData, 0)
+	ip.pendingSet = make([]*IdIdenStateData, 0)
+}
+
+// GetState returns the Identity State Data of the given ID from the IdenStates Smart Contract.
+func (ip *IdenPubOnChain) GetState(id *core.ID) (*proof.IdenStateData, error) {
+	ip.rw.RLock()
+	defer ip.rw.RUnlock()
+	idenStatesData, ok := ip.idenStatesData[*id]
+	if !ok {
+		return nil, idenpubonchain.ErrIdenNotOnChain
+	}
+	return idenStatesData.IdenStates[len(idenStatesData.IdenStates)-1], nil
+}
+
+// GetStateByBlock returns the Identity State Data of the given ID published at
+// queryBlockN from the IdenStates Smart Contract.
+func (ip *IdenPubOnChain) GetStateByBlock(id *core.ID, queryBlockN uint64) (*proof.IdenStateData, error) {
+	ip.rw.RLock()
+	defer ip.rw.RUnlock()
+	idenStatesData, ok := ip.idenStatesData[*id]
+	if !ok {
+		return nil, idenpubonchain.ErrIdenNotOnChain
+	}
+	idenState, ok := idenStatesData.ByBlock[queryBlockN]
+	if !ok {
+		return nil, idenpubonchain.ErrIdenByBlockNotFound
+	}
+	return idenState, nil
+}
+
+// GetStateByTime returns the Identity State Data of the given ID published at
+// queryBlockTs from the IdenStates Smart Contract.
+func (ip *IdenPubOnChain) GetStateByTime(id *core.ID, queryBlockTs int64) (*proof.IdenStateData, error) {
+	ip.rw.RLock()
+	defer ip.rw.RUnlock()
+	idenStatesData, ok := ip.idenStatesData[*id]
+	if !ok {
+		return nil, idenpubonchain.ErrIdenNotOnChain
+	}
+	idenState, ok := idenStatesData.ByTime[queryBlockTs]
+	if !ok {
+		return nil, idenpubonchain.ErrIdenByTimeNotFound
+	}
+	return idenState, nil
+}
+
+// splitSignature splits the signature returning (sigR8, sigS)
+func splitSignature(signature *babyjub.SignatureComp) (sigR8 [32]byte, sigS [32]byte) {
+	copy(sigR8[:], signature[:32])
+	copy(sigS[:], signature[32:])
+	return sigR8, sigS
+}
+
+// SetState updates the Identity State of the given ID in the IdenStates Smart Contract.
+func (ip *IdenPubOnChain) SetState(id *core.ID, newState *merkletree.Hash, kOpProof []byte,
+	stateTransitionProof []byte, signature *babyjub.SignatureComp) (*types.Transaction, error) {
+	ip.rw.Lock()
+	defer ip.rw.Unlock()
+	_, ok := ip.idenStatesData[*id]
+	if !ok {
+		return nil, idenpubonchain.ErrIdenNotOnChain
+	}
+	idenState := proof.IdenStateData{
+		BlockN:    ip.blockNow(),
+		BlockTs:   ip.timeNow().Unix(),
+		IdenState: newState,
+	}
+	ip.pendingSet = append(ip.pendingSet, &IdIdenStateData{Id: id, IdenStateData: &idenState})
+	return &types.Transaction{}, nil
+}
+
+// InitState initializes the first Identity State of the given ID in the IdenStates Smart Contract.
+func (ip *IdenPubOnChain) InitState(id *core.ID, genesisState *merkletree.Hash,
+	newState *merkletree.Hash, kOpProof []byte, stateTransitionProof []byte,
+	signature *babyjub.SignatureComp) (*types.Transaction, error) {
+	ip.rw.Lock()
+	defer ip.rw.Unlock()
+	_, ok := ip.idenStatesData[*id]
+	if ok {
+		return nil, fmt.Errorf("Identity already exists on chain")
+	}
+	idenState := proof.IdenStateData{
+		BlockN:    ip.blockNow(),
+		BlockTs:   ip.timeNow().Unix(),
+		IdenState: newState,
+	}
+	ip.pendingInit = append(ip.pendingInit, &IdIdenStateData{Id: id, IdenStateData: &idenState})
+	return &types.Transaction{}, nil
+}

--- a/components/idenpubonchain/local/local.go
+++ b/components/idenpubonchain/local/local.go
@@ -119,13 +119,6 @@ func (ip *IdenPubOnChain) GetStateByTime(id *core.ID, queryBlockTs int64) (*proo
 	return idenState, nil
 }
 
-// splitSignature splits the signature returning (sigR8, sigS)
-func splitSignature(signature *babyjub.SignatureComp) (sigR8 [32]byte, sigS [32]byte) {
-	copy(sigR8[:], signature[:32])
-	copy(sigS[:], signature[32:])
-	return sigR8, sigS
-}
-
 // SetState updates the Identity State of the given ID in the IdenStates Smart Contract.
 func (ip *IdenPubOnChain) SetState(id *core.ID, newState *merkletree.Hash, kOpProof []byte,
 	stateTransitionProof []byte, signature *babyjub.SignatureComp) (*types.Transaction, error) {

--- a/identity/issuer/issuer.go
+++ b/identity/issuer/issuer.go
@@ -603,7 +603,7 @@ func (is *Issuer) PublishState() error {
 	}
 
 	// finally, Publish the Public Off Chain identity data
-	if err := is.idenPubOffChainWriter.Publish(&publicData); err != nil {
+	if err := is.idenPubOffChainWriter.Publish(is.id, &publicData); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This is an implementation of the identity states smart contract in go.  Right now it behaves the same way as the smart contract (that is, it doesn't check any signature).

The idea is to use this in the tests, and to extend it to
- verify the signature
- verify the proof of kOp

Hopefully having this implementation will make testing the real smart contract easier!