### PR TITLE
Fix #348 approach A

### DIFF
--- a/components/verifier/verifier.go
+++ b/components/verifier/verifier.go
@@ -47,7 +47,11 @@ func (v *Verifier) VerifyCredentialExistence(credExist *proof.CredentialExistenc
 	}
 	// Verify that the idenState is built from claims merkle tree where the
 	// claim exists.
-	claimsRoot, err := merkletree.RootFromProof(credExist.MtpClaim, credExist.Claim.HIndex(), credExist.Claim.HValue())
+	hi, hv, err := credExist.Claim.HiHv()
+	if err != nil {
+		return err
+	}
+	claimsRoot, err := merkletree.RootFromProof(credExist.MtpClaim, hi, hv)
 	if err != nil {
 		return err
 	}
@@ -107,7 +111,11 @@ func (v *Verifier) VerifyCredentialValidity(credValid *proof.CredentialValidity,
 	// NOTE: Once we add versions, this will require some changes that need to be thought properly!
 	nonce := claims.GetRevocationNonce(credValid.CredentialExistence.Claim)
 	revLeaf := claims.NewLeafRevocationsTree(nonce, 0xffffffff).Entry()
-	revocationsTreeRoot, err := merkletree.RootFromProof(credValid.MtpNotNonce, revLeaf.HIndex(), revLeaf.HValue())
+	hi, hv, err := revLeaf.HiHv()
+	if err != nil {
+		return err
+	}
+	revocationsTreeRoot, err := merkletree.RootFromProof(credValid.MtpNotNonce, hi, hv)
 	if err != nil {
 		return err
 	}

--- a/components/verifier/verifier_test.go
+++ b/components/verifier/verifier_test.go
@@ -108,7 +108,7 @@ func TestVerifyCredentialExistence(t *testing.T) {
 	// Cred Exist has bad RootsTreeRoot
 	credExistBad = &proof.CredentialExistence{}
 	Copy(credExistBad, credExist)
-	credExistBad.RootsTreeRoot[0] = 0x00
+	credExistBad.RootsTreeRoot[1] ^= 0xff
 	require.NotEqual(t, credExist, credExistBad)
 	err = verifier.VerifyCredentialExistence(credExistBad)
 	assert.NotNil(t, err)
@@ -116,7 +116,7 @@ func TestVerifyCredentialExistence(t *testing.T) {
 	// Cred Exist has bad IdenState
 	credExistBad = &proof.CredentialExistence{}
 	Copy(credExistBad, credExist)
-	credExistBad.IdenStateData.IdenState[1] = 0x00
+	credExistBad.IdenStateData.IdenState[1] ^= 0xff
 	require.NotEqual(t, credExist, credExistBad)
 	err = verifier.VerifyCredentialExistence(credExistBad)
 	assert.NotNil(t, err)

--- a/core/claims/claimAuthorizeKSignBabyJub_test.go
+++ b/core/claims/claimAuthorizeKSignBabyJub_test.go
@@ -23,8 +23,10 @@ func testClaimAuthorizeKSignBabyJub(t *testing.T, i, testKey string) {
 	assert.True(t, merkletree.CheckEntryInField(*c0.Entry()))
 	e := c0.Entry()
 	// Check claim against test vector
-	testgen.CheckTestValue(t, "ClaimAuthorizeKSignBabyJub"+i+"_HIndex", e.HIndex().Hex())
-	testgen.CheckTestValue(t, "ClaimAuthorizeKSignBabyJub"+i+"_HValue", e.HValue().Hex())
+	hi, hv, err := e.HiHv()
+	assert.Nil(t, err)
+	testgen.CheckTestValue(t, "ClaimAuthorizeKSignBabyJub"+i+"_HIndex", hi.Hex())
+	testgen.CheckTestValue(t, "ClaimAuthorizeKSignBabyJub"+i+"_HValue", hv.Hex())
 	testgen.CheckTestValue(t, "ClaimAuthorizeKSignBabyJub"+i+"_dataString", e.Data.String())
 	dataTestOutput(&e.Data)
 	c1 := NewClaimAuthorizeKSignBabyJubFromEntry(e)

--- a/core/claims/claimBasic_test.go
+++ b/core/claims/claimBasic_test.go
@@ -23,8 +23,10 @@ func TestClaimBasic(t *testing.T) {
 	c0.Metadata().RevNonce = 5678
 	e := c0.Entry()
 	// Check claim against test vector
-	testgen.CheckTestValue(t, "ClaimBasic0_HIndex", e.HIndex().Hex())
-	testgen.CheckTestValue(t, "ClaimBasic0_HValue", e.HValue().Hex())
+	hi, hv, err := e.HiHv()
+	assert.Nil(t, err)
+	testgen.CheckTestValue(t, "ClaimBasic0_HIndex", hi.Hex())
+	testgen.CheckTestValue(t, "ClaimBasic0_HValue", hv.Hex())
 	testgen.CheckTestValue(t, "ClaimBasic0_dataString", e.Data.String())
 	dataTestOutput(&e.Data)
 	c1 := NewClaimBasicFromEntry(e)
@@ -48,9 +50,11 @@ func TestClaimBasic1(t *testing.T) {
 	// ClaimBasic
 	c0 := NewClaimBasic(indexSlot, valueSlot)
 	e := c0.Entry()
+	hi, hv, err := e.HiHv()
+	assert.Nil(t, err)
 	// Check claim against test vector
-	testgen.CheckTestValue(t, "ClaimBasic1_HIndex", e.HIndex().Hex())
-	testgen.CheckTestValue(t, "ClaimBasic1_HValue", e.HValue().Hex())
+	testgen.CheckTestValue(t, "ClaimBasic1_HIndex", hi.Hex())
+	testgen.CheckTestValue(t, "ClaimBasic1_HValue", hv.Hex())
 	testgen.CheckTestValue(t, "ClaimBasic1_dataString", e.Data.String())
 	dataTestOutput(&e.Data)
 	c1 := NewClaimBasicFromEntry(e)

--- a/core/claims/revocationrootsleafs_test.go
+++ b/core/claims/revocationrootsleafs_test.go
@@ -16,8 +16,10 @@ func TestLeafRootsTree(t *testing.T) {
 	l0 := NewLeafRootsTree(root)
 	e := l0.Entry()
 
-	testgen.CheckTestValue(t, "Leaf0_HIndex", e.HIndex().Hex())
-	testgen.CheckTestValue(t, "Leaf0_HValue", e.HValue().Hex())
+	hi, hv, err := e.HiHv()
+	assert.Nil(t, err)
+	testgen.CheckTestValue(t, "Leaf0_HIndex", hi.Hex())
+	testgen.CheckTestValue(t, "Leaf0_HValue", hv.Hex())
 	testgen.CheckTestValue(t, "Leaf0_dataString", e.Data.String())
 	l1 := NewLeafRootsTreeFromEntry(e)
 	assert.Equal(t, l0, l1)
@@ -33,8 +35,10 @@ func TestLeafRevocationsTree(t *testing.T) {
 	l0 := NewLeafRevocationsTree(nonce, version)
 	e := l0.Entry()
 
-	testgen.CheckTestValue(t, "Leaf1_HIndex", e.HIndex().Hex())
-	testgen.CheckTestValue(t, "Leaf1_HValue", e.HValue().Hex())
+	hi, hv, err := e.HiHv()
+	assert.Nil(t, err)
+	testgen.CheckTestValue(t, "Leaf1_HIndex", hi.Hex())
+	testgen.CheckTestValue(t, "Leaf1_HValue", hv.Hex())
 	testgen.CheckTestValue(t, "Leaf1_dataString", e.Data.String())
 	l1 := NewLeafRevocationsTreeFromEntry(e)
 	assert.Equal(t, l0, l1)
@@ -55,7 +59,9 @@ func TestAddLeafRootsTree(t *testing.T) {
 	assert.Nil(t, err)
 	testgen.CheckTestValue(t, "rootRootsTree0", mt.RootKey().Hex())
 
-	proof, err := mt.GenerateProof(NewLeafRootsTree(root).Entry().HIndex(), nil)
+	hi, err := NewLeafRootsTree(root).Entry().HIndex()
+	assert.Nil(t, err)
+	proof, err := mt.GenerateProof(hi, nil)
 	assert.Nil(t, err)
 	testgen.CheckTestValue(t, "proofLeafRootsTree", hex.EncodeToString(proof.Bytes()))
 }
@@ -71,7 +77,9 @@ func TestAddLeafRevocationsTree(t *testing.T) {
 	assert.Nil(t, err)
 	testgen.CheckTestValue(t, "rootRevocationsTree0", mt.RootKey().Hex())
 
-	proof, err := mt.GenerateProof(NewLeafRevocationsTree(nonce, version).Entry().HIndex(), nil)
+	hi, err := NewLeafRevocationsTree(nonce, version).Entry().HIndex()
+	assert.Nil(t, err)
+	proof, err := mt.GenerateProof(hi, nil)
 	assert.Nil(t, err)
 	testgen.CheckTestValue(t, "proofRevocationsTree", hex.EncodeToString(proof.Bytes()))
 }

--- a/identity/holder/holder.go
+++ b/identity/holder/holder.go
@@ -77,7 +77,11 @@ func (h *Holder) HolderGetCredentialValidity(
 	claimMetadata.Unmarshal(credExist.Claim)
 	// NOTE: Once we add versions, this will require some changes that need to be thought properly!
 	revLeaf := claims.NewLeafRevocationsTree(claimMetadata.RevNonce, 0xffffffff).Entry()
-	mtpNotNonce, err := publicData.RevocationsTree.GenerateProof(revLeaf.HIndex(), nil)
+	revLeafHi, err := revLeaf.HIndex()
+	if err != nil {
+		return nil, err
+	}
+	mtpNotNonce, err := publicData.RevocationsTree.GenerateProof(revLeafHi, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/identity/issuer/issuer.go
+++ b/identity/issuer/issuer.go
@@ -622,7 +622,12 @@ func (is *Issuer) RevokeClaim(claim merkletree.Entrier) error {
 	}
 	is.rw.Lock()
 	defer is.rw.Unlock()
-	data, err := is.claimsTree.GetDataByIndex(claim.Entry().HIndex())
+
+	hi, err := claim.Entry().HIndex()
+	if err != nil {
+		return err
+	}
+	data, err := is.claimsTree.GetDataByIndex(hi)
 	if err != nil {
 		return err
 	}
@@ -711,7 +716,11 @@ func (is *Issuer) GenCredentialExistence(claim merkletree.Entrier) (*proof.Crede
 		return nil, err
 	}
 	claimEntry := claim.Entry()
-	mtpExist, err := generateExistenceMTProof(is.claimsTree, claimEntry.HIndex(),
+	hi, err := claimEntry.HIndex()
+	if err != nil {
+		return nil, err
+	}
+	mtpExist, err := generateExistenceMTProof(is.claimsTree, hi,
 		idenStateTreeRoots.ClaimsTreeRoot)
 	if err != nil {
 		// We were unable to generate a proof from the claims tree

--- a/merkletree/merkletree_test.go
+++ b/merkletree/merkletree_test.go
@@ -83,7 +83,9 @@ func TestEntry(t *testing.T) {
 	// in := testgen.GetTestValue("EntryInts0").([]int64)
 	in := interfaceToInt64Array(testgen.GetTestValue("EntryInts0"))
 	e := NewEntryFromIntArray(in)
-	testgen.CheckTestValue(t, "TestEntry0", hex.EncodeToString(e.HIndex()[:]))
+	hi, err := e.HIndex()
+	assert.Nil(t, err)
+	testgen.CheckTestValue(t, "TestEntry0", hex.EncodeToString(hi[:]))
 }
 
 func TestData(t *testing.T) {
@@ -163,16 +165,24 @@ func TestEntriesIndex(t *testing.T) {
 	// Two entries with different Index generate different hash index
 	in := interfaceToInt64Array(testgen.GetTestValue("EntryInts4"))
 	a := NewEntryFromIntArray(in)
+	aHi, err := a.HIndex()
+	assert.Nil(t, err)
 	in = interfaceToInt64Array(testgen.GetTestValue("EntryInts5"))
 	b := NewEntryFromIntArray(in)
-	assert.NotEqual(t, a.HIndex(), b.HIndex())
+	bHi, err := b.HIndex()
+	assert.Nil(t, err)
+	assert.NotEqual(t, aHi, bHi)
 
 	// Two entries with same Index generate the same hash index
 	in = interfaceToInt64Array(testgen.GetTestValue("EntryInts6"))
 	c := NewEntryFromIntArray(in)
+	cHi, err := c.HIndex()
+	assert.Nil(t, err)
 	in = interfaceToInt64Array(testgen.GetTestValue("EntryInts7"))
 	d := NewEntryFromIntArray(in)
-	assert.Equal(t, c.HIndex(), d.HIndex())
+	dHi, err := d.HIndex()
+	assert.Nil(t, err)
+	assert.Equal(t, cHi, dHi)
 }
 
 func TestGetEntry2(t *testing.T) {
@@ -186,11 +196,13 @@ func TestGetEntry2(t *testing.T) {
 	}
 	in = interfaceToInt64Array(testgen.GetTestValue("EntryInts1"))
 	e = NewEntryFromIntArray(in)
+	hi, err := e.HIndex()
+	assert.Nil(t, err)
 	if err := mt.AddEntry(&e); err != nil {
 		t.Fatal(err)
 	}
 
-	data, err := mt.GetDataByIndex(e.HIndex())
+	data, err := mt.GetDataByIndex(hi)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -205,11 +217,13 @@ func TestGenerateProof1(t *testing.T) {
 
 	in := interfaceToInt64Array(testgen.GetTestValue("EntryInts8"))
 	e := NewEntryFromIntArray(in)
+	hi, err := e.HIndex()
+	assert.Nil(t, err)
 	if err := mt.AddEntry(&e); err != nil {
 		t.Fatal(err)
 	}
 
-	proof, err := mt.GenerateProof(e.HIndex(), nil)
+	proof, err := mt.GenerateProof(hi, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -228,8 +242,10 @@ func TestGenerateProof4(t *testing.T) {
 	}
 
 	e := NewEntryFromInts(int64(2), 0, 0, 0, 0, 0, 0, 0)
+	hi, err := e.HIndex()
+	assert.Nil(t, err)
 
-	data, err := mt.GetDataByIndex(e.HIndex())
+	data, err := mt.GetDataByIndex(hi)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -237,7 +253,7 @@ func TestGenerateProof4(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	proof, err := mt.GenerateProof(e.HIndex(), nil)
+	proof, err := mt.GenerateProof(hi, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -257,8 +273,10 @@ func TestGenerateProof64(t *testing.T) {
 	}
 
 	e := NewEntryFromInts(int64(4), 0, 0, 0, 0, 0, 0, 0)
+	hi, err := e.HIndex()
+	assert.Nil(t, err)
 
-	data, err := mt.GetDataByIndex(e.HIndex())
+	data, err := mt.GetDataByIndex(hi)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -266,7 +284,7 @@ func TestGenerateProof64(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	proof, err := mt.GenerateProof(e.HIndex(), nil)
+	proof, err := mt.GenerateProof(hi, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -286,13 +304,15 @@ func TestVerifyProof1(t *testing.T) {
 	}
 
 	e := NewEntryFromInts(int64(4), 0, 0, 0, 0, 0, 0, 0)
+	hi, hv, err := e.HiHv()
+	assert.Nil(t, err)
 
-	proof, err := mt.GenerateProof(e.HIndex(), nil)
+	proof, err := mt.GenerateProof(hi, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	verify := VerifyProof(mt.RootKey(), proof, e.HIndex(), e.HValue())
+	verify := VerifyProof(mt.RootKey(), proof, hi, hv)
 	assert.True(t, verify)
 	proofTestOutput(proof)
 	testgen.CheckTestValue(t, "TestVerifyProof1", hex.EncodeToString(proof.Bytes()))
@@ -310,13 +330,15 @@ func TestVerifyProofEmpty(t *testing.T) {
 	}
 
 	e := NewEntryFromInts(int64(42), 0, 0, 0, 0, 0, 0, 0)
+	hi, hv, err := e.HiHv()
+	assert.Nil(t, err)
 
-	proof, err := mt.GenerateProof(e.HIndex(), nil)
+	proof, err := mt.GenerateProof(hi, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	verify := VerifyProof(mt.RootKey(), proof, e.HIndex(), e.HValue())
+	verify := VerifyProof(mt.RootKey(), proof, hi, hv)
 	assert.True(t, verify)
 	proofTestOutput(proof)
 	testgen.CheckTestValue(t, "TestVerifyProofEmpty", hex.EncodeToString(proof.Bytes()))
@@ -335,18 +357,23 @@ func TestVerifyProofCases(t *testing.T) {
 
 	// Existence proof
 	e := NewEntryFromInts(int64(4), 0, 0, 0, 0, 0, 0, 0)
-	proof, err := mt.GenerateProof(e.HIndex(), nil)
+	hi, hv, err := e.HiHv()
+	assert.Nil(t, err)
+
+	proof, err := mt.GenerateProof(hi, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, proof.Existence, true)
-	assert.True(t, VerifyProof(mt.RootKey(), proof, e.HIndex(), e.HValue()))
+	assert.True(t, VerifyProof(mt.RootKey(), proof, hi, hv))
 	proofTestOutput(proof)
 	testgen.CheckTestValue(t, "TestVerifyProofCases0", hex.EncodeToString(proof.Bytes()))
 
 	for i := 8; i < 32; i++ {
 		e := NewEntryFromInts(int64(i), 0, 0, 0, 0, 0, 0, 0)
-		proof, err = mt.GenerateProof(e.HIndex(), nil)
+		hi, err := e.HIndex()
+		assert.Nil(t, err)
+		proof, err = mt.GenerateProof(hi, nil)
 		assert.Nil(t, err)
 		if debug {
 			fmt.Println(i, proof)
@@ -354,25 +381,29 @@ func TestVerifyProofCases(t *testing.T) {
 	}
 	// Non-existence proof, empty aux
 	e = NewEntryFromInts(int64(12), 0, 0, 0, 0, 0, 0, 0)
-	proof, err = mt.GenerateProof(e.HIndex(), nil)
+	hi, hv, err = e.HiHv()
+	assert.Nil(t, err)
+	proof, err = mt.GenerateProof(hi, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, proof.Existence, false)
 	// assert.True(t, proof.nodeAux == nil)
-	assert.True(t, VerifyProof(mt.RootKey(), proof, e.HIndex(), e.HValue()))
+	assert.True(t, VerifyProof(mt.RootKey(), proof, hi, hv))
 	proofTestOutput(proof)
 	testgen.CheckTestValue(t, "TestVerifyProofCases1", hex.EncodeToString(proof.Bytes()))
 
 	// Non-existence proof, diff. node aux
 	e = NewEntryFromInts(int64(10), 0, 0, 0, 0, 0, 0, 0)
-	proof, err = mt.GenerateProof(e.HIndex(), nil)
+	hi, hv, err = e.HiHv()
+	assert.Nil(t, err)
+	proof, err = mt.GenerateProof(hi, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, proof.Existence, false)
 	// assert.True(t, proof.nodeAux != nil)
-	assert.True(t, VerifyProof(mt.RootKey(), proof, e.HIndex(), e.HValue()))
+	assert.True(t, VerifyProof(mt.RootKey(), proof, hi, hv))
 	proofTestOutput(proof)
 	testgen.CheckTestValue(t, "TestVerifyProofCases2", hex.EncodeToString(proof.Bytes()))
 }
@@ -391,17 +422,23 @@ func TestVerifyProofFalse(t *testing.T) {
 	// Invalid existence proof (node used for verification doesn't
 	// correspond to node in the proof)
 	e := NewEntryFromInts(int64(4), 0, 0, 0, 0, 0, 0, 0)
-	proof, err := mt.GenerateProof(e.HIndex(), nil)
+	hi, err := e.HIndex()
+	assert.Nil(t, err)
+	proof, err := mt.GenerateProof(hi, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, proof.Existence, true)
 	e1 := NewEntryFromInts(int64(5), 0, 0, 0, int64(5), 0, 0, 0)
-	assert.True(t, !VerifyProof(mt.RootKey(), proof, e1.HIndex(), e1.HValue()))
+	hi, hv, err := e1.HiHv()
+	assert.Nil(t, err)
+	assert.True(t, !VerifyProof(mt.RootKey(), proof, hi, hv))
 
 	// Invalid non-existence proof (Non-existence proof, diff. node aux)
 	e = NewEntryFromInts(int64(4), 0, 0, 0, 0, 0, 0, 0)
-	proof, err = mt.GenerateProof(e.HIndex(), nil)
+	hi, err = e.HIndex()
+	assert.Nil(t, err)
+	proof, err = mt.GenerateProof(hi, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -409,8 +446,10 @@ func TestVerifyProofFalse(t *testing.T) {
 	// Now we change the proof from existence to non-existence, and add e's
 	// data as auxiliary node.
 	proof.Existence = false
-	proof.nodeAux = &nodeAux{hIndex: e.HIndex(), hValue: e.HValue()}
-	assert.True(t, !VerifyProof(mt.RootKey(), proof, e.HIndex(), e.HValue()))
+	hi, hv, err = e.HiHv()
+	assert.Nil(t, err)
+	proof.nodeAux = &nodeAux{hIndex: hi, hValue: hv}
+	assert.True(t, !VerifyProof(mt.RootKey(), proof, hi, hv))
 }
 
 func TestProofFromBytesSmall(t *testing.T) {
@@ -423,7 +462,9 @@ func TestProofFromBytesSmall(t *testing.T) {
 	}
 
 	// Proof of existence, single claim MT
-	proof0, err := mt.GenerateProof(e0.HIndex(), nil)
+	hi, err := e0.HIndex()
+	assert.Nil(t, err)
+	proof0, err := mt.GenerateProof(hi, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -433,7 +474,9 @@ func TestProofFromBytesSmall(t *testing.T) {
 
 	// Proof of non-existence with aux node, single claim MT
 	e2 := NewEntryFromInts(int64(1), 0, 0, 0, 0, 0, 0, 0)
-	proof2, err := mt.GenerateProof(e2.HIndex(), nil)
+	hi, err = e2.HIndex()
+	assert.Nil(t, err)
+	proof2, err := mt.GenerateProof(hi, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -455,7 +498,9 @@ func TestProofFromBytesBig(t *testing.T) {
 
 	// Proof of existence, single claim MT
 	e0 := NewEntryFromInts(0, 0, 0, 0, 0, 0, 0, 0)
-	proof0, err := mt.GenerateProof(e0.HIndex(), nil)
+	hi, err := e0.HIndex()
+	assert.Nil(t, err)
+	proof0, err := mt.GenerateProof(hi, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -465,7 +510,9 @@ func TestProofFromBytesBig(t *testing.T) {
 
 	// Proof of non-existence with empty node, single claim MT
 	e1 := NewEntryFromInts(int64(17), 0, 0, 0, 0, 0, 0, 0)
-	proof1, err := mt.GenerateProof(e1.HIndex(), nil)
+	hi, err = e1.HIndex()
+	assert.Nil(t, err)
+	proof1, err := mt.GenerateProof(hi, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -475,7 +522,9 @@ func TestProofFromBytesBig(t *testing.T) {
 
 	// Proof of non-existence with aux node, single claim MT
 	e2 := NewEntryFromInts(0, int64(17), 0, 0, 0, 0, 0, 0)
-	proof2, err := mt.GenerateProof(e2.HIndex(), nil)
+	hi, err = e2.HIndex()
+	assert.Nil(t, err)
+	proof2, err := mt.GenerateProof(hi, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/merkletree/utils.go
+++ b/merkletree/utils.go
@@ -63,20 +63,20 @@ func BigIntToHash(e *big.Int) (h Hash) {
 	return h
 }
 
-// HashElems performs a mimc7 hash over the array of ElemBytes.
-func HashElems(elems ...ElemBytes) *Hash {
+// HashElems performs a poseidon hash over the array of ElemBytes.
+func HashElems(elems ...ElemBytes) (*Hash, error) {
 	bigints := ElemBytesToBigInts(elems...)
 	// mimcHash, err := mimc7.Hash(bigints, nil)
 	poseidonHash, err := poseidon.Hash(bigints)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	h := BigIntToHash(poseidonHash)
-	return &h
+	return &h, nil
 }
 
-// HashElemsKey performs a mimc7 hash over the array of ElemBytes.
-func HashElemsKey(key *big.Int, elems ...ElemBytes) *Hash {
+// HashElemsKey performs a poseidon hash over the array of ElemBytes.
+func HashElemsKey(key *big.Int, elems ...ElemBytes) (*Hash, error) {
 	bigints := ElemBytesToBigInts(elems...)
 	// mimcHash, err := mimc7.Hash(bigints, key)
 	if key != nil {
@@ -84,10 +84,10 @@ func HashElemsKey(key *big.Int, elems ...ElemBytes) *Hash {
 	}
 	poseidonHash, err := poseidon.Hash(bigints)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	h := BigIntToHash(poseidonHash)
-	return &h
+	return &h, nil
 }
 
 // getPath returns the binary path, from the root to the leaf.

--- a/merkletree/utils_test.go
+++ b/merkletree/utils_test.go
@@ -29,25 +29,29 @@ func TestGetSetBitmap(t *testing.T) {
 func TestHashElems(t *testing.T) {
 	in := interfaceToInt64Array(testgen.GetTestValue("TestHashElems0"))
 	d := IntsToData(in[0], in[1], in[2], in[3], in[4], in[5], in[6], in[7])
-	h := HashElems(d[:]...)
+	h, err := HashElems(d[:]...)
+	assert.Nil(t, err)
 	hashTestOutput(h)
 	testgen.CheckTestValue(t, "TestHashElems0", h.Hex())
 
 	in = interfaceToInt64Array(testgen.GetTestValue("TestHashElems1"))
 	d = IntsToData(in[0], in[1], in[2], in[3], in[4], in[5], in[6], in[7])
-	h = HashElems(d[:]...)
+	h, err = HashElems(d[:]...)
+	assert.Nil(t, err)
 	hashTestOutput(h)
 	testgen.CheckTestValue(t, "TestHashElems1", h.Hex())
 
 	in = interfaceToInt64Array(testgen.GetTestValue("TestHashElems2"))
 	d = IntsToData(in[0], in[1], in[2], in[3], in[4], in[5], in[6], in[7])
-	h = HashElems(d[:]...)
+	h, err = HashElems(d[:]...)
+	assert.Nil(t, err)
 	hashTestOutput(h)
 	testgen.CheckTestValue(t, "TestHashElems2", h.Hex())
 
 	in = interfaceToInt64Array(testgen.GetTestValue("EntryInts0"))
 	d = IntsToData(in[0], in[1], in[2], in[3], in[4], in[5], in[6], in[7])
-	h = HashElems(d[:]...)
+	h, err = HashElems(d[:]...)
+	assert.Nil(t, err)
 	hashTestOutput(h)
 	testgen.CheckTestValue(t, "TestHashElems3", h.Hex())
 }


### PR DESCRIPTION
Adds the error managing to the Poseidon Hash calls, instead of giving a panic when the error is reached. Updates the rest of packages on the new usage of the functions where the hash is involved.

The error when calling Poseidon Hash should never be reached, as is only triggered when the inputs of the hash are outside the Finite Field. But, as this is a core package used by other packages, the panic should not exist or at least should not be reachable.

We evaluated also an 'approach B' ( https://github.com/iden3/go-iden3-core/tree/fix/348b ), where the panic still is there but should never be reachable, as the solution is around creating a secure API wrapping ElemBytes in a way that is impossible to create new ones outside the Finite Field (returning an error in the case that is outside), in a way that the panic of the Poseidon Hash call should not be reachable. This approach adds extra complexity in the outside package usage of the ElemBytes, and opens possible holes in the future in the case that something is changed and the panic is reachable again. That's why for the moment we implemented the 'approach A'.

resolves #348 