### PR TITLE
Feature/waitblocks

### DIFF
--- a/components/idenpubonchain/idenpubonchain.go
+++ b/components/idenpubonchain/idenpubonchain.go
@@ -34,6 +34,7 @@ type IdenPubOnChainer interface {
 	InitState(id *core.ID, genesisState *merkletree.Hash,
 		newState *merkletree.Hash, kOp *babyjub.PublicKey, stateTransitionProof []byte,
 		signature *babyjub.SignatureComp) (*types.Transaction, error)
+	TxConfirmBlocks(tx *types.Transaction) (*big.Int, error)
 	// VerifyProofClaim(pc *proof.ProofClaim) (bool, error)
 }
 
@@ -214,4 +215,17 @@ func (ip *IdenPubOnChain) InitState(id *core.ID, genesisState *merkletree.Hash,
 	} else {
 		return tx, nil
 	}
+}
+
+// TxConfirmBlocks returns the number of confirmed blocks of transaction tx.
+func (ip *IdenPubOnChain) TxConfirmBlocks(tx *types.Transaction) (*big.Int, error) {
+	receipt, err := ip.client.GetReceipt(tx)
+	if err != nil {
+		return nil, err
+	}
+	currentBlock, err := ip.client.CurrentBlock()
+	if err != nil {
+		return nil, err
+	}
+	return currentBlock.Sub(currentBlock, receipt.BlockNumber), nil
 }

--- a/components/idenpubonchain/local/local.go
+++ b/components/idenpubonchain/local/local.go
@@ -2,9 +2,11 @@ package local
 
 import (
 	"fmt"
+	"math/big"
 	"sync"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/iden3/go-iden3-core/components/idenpubonchain"
 	"github.com/iden3/go-iden3-core/core"
@@ -155,5 +157,14 @@ func (ip *IdenPubOnChain) InitState(id *core.ID, genesisState *merkletree.Hash,
 		IdenState: newState,
 	}
 	ip.pendingInit = append(ip.pendingInit, &IdIdenStateData{Id: id, IdenStateData: &idenState})
-	return &types.Transaction{}, nil
+	return types.NewTransaction(0, common.Address{}, nil, 0, nil,
+		new(big.Int).SetUint64(ip.blockNow()).Bytes()), nil
+}
+
+// TxConfirmBlocks returns the number of confirmed blocks of transaction tx.
+func (ip *IdenPubOnChain) TxConfirmBlocks(tx *types.Transaction) (*big.Int, error) {
+	blockNumber := new(big.Int).SetBytes(tx.Data())
+	currentBlock := new(big.Int).SetUint64(ip.blockNow())
+	return currentBlock.Sub(currentBlock, blockNumber), nil
+	// return new(big.Int).SetUint64(99999999), nil
 }

--- a/components/verifier/verifier_test.go
+++ b/components/verifier/verifier_test.go
@@ -73,6 +73,8 @@ func TestVerifyCredentialExistence(t *testing.T) {
 	require.Nil(t, err)
 	idenPubOnChain.Sync()
 
+	blockTs += 20
+	blockN += 10
 	err = is.SyncIdenStatePublic()
 	require.Nil(t, err)
 
@@ -175,9 +177,9 @@ func TestVerifyCredentialValidity(t *testing.T) {
 	ho, _, _ := newHolder(t, idenPubOnChain, nil, idenPubOffChain)
 
 	//
-	// {Ts: 100, BlockN: 12} -> claim1 is added
+	// {Ts: 1000, BlockN: 120} -> claim1 is added
 	//
-	blockTs, blockN = 100, 12
+	blockTs, blockN = 1000, 120
 
 	// ISSUER: Publish state first time with claim1
 
@@ -194,6 +196,9 @@ func TestVerifyCredentialValidity(t *testing.T) {
 	require.Nil(t, err)
 	idenPubOnChain.Sync()
 
+	blockTs += 20
+	blockN += 10
+
 	err = is.SyncIdenStatePublic()
 	require.Nil(t, err)
 
@@ -205,13 +210,13 @@ func TestVerifyCredentialValidity(t *testing.T) {
 	credValidClaim1t1, err := ho.HolderGetCredentialValidity(credExistClaim1)
 	require.Nil(t, err)
 
-	err = verifier.VerifyCredentialValidity(credValidClaim1t1, 50*time.Second)
+	err = verifier.VerifyCredentialValidity(credValidClaim1t1, 500*time.Second)
 	assert.Nil(t, err)
 
 	//
-	// {Ts: 200, BlockN: 13} -> claim2 is added
+	// {Ts: 2000, BlockN: 130} -> claim2 is added
 	//
-	blockTs, blockN = 200, 13
+	blockTs, blockN = 2000, 130
 
 	// ISSUER: Publish state a second time with another claim2, claim3
 
@@ -222,7 +227,7 @@ func TestVerifyCredentialValidity(t *testing.T) {
 	err = is.IssueClaim(claim2)
 	require.Nil(t, err)
 
-	// claim3 is a claim with expiration at T=350
+	// claim3 is a claim with expiration at T=3500
 
 	header := claims.ClaimHeader{
 		Type:       claims.NewClaimTypeNum(9999),
@@ -231,7 +236,7 @@ func TestVerifyCredentialValidity(t *testing.T) {
 		Version:    false,
 	}
 	metadata := claims.NewMetadata(header)
-	metadata.Expiration = 350
+	metadata.Expiration = 3500
 	var entry merkletree.Entry
 	metadata.Marshal(&entry)
 	claim3 := claims.NewClaimGeneric(&entry)
@@ -262,24 +267,24 @@ func TestVerifyCredentialValidity(t *testing.T) {
 	assert.NotNil(t, credValidClaim2t2)
 
 	// Outdated is invalid
-	err = verifier.VerifyCredentialValidity(credValidClaim1t1, 50*time.Second)
+	err = verifier.VerifyCredentialValidity(credValidClaim1t1, 500*time.Second)
 	assert.Error(t, err)
 
 	// With more freshness time it's valid
-	err = verifier.VerifyCredentialValidity(credValidClaim1t1, 150*time.Second)
+	err = verifier.VerifyCredentialValidity(credValidClaim1t1, 1500*time.Second)
 	assert.Nil(t, err)
 
 	// Recent one is valid
-	err = verifier.VerifyCredentialValidity(credValidClaim1t2, 50*time.Second)
+	err = verifier.VerifyCredentialValidity(credValidClaim1t2, 500*time.Second)
 	assert.Nil(t, err)
 
-	err = verifier.VerifyCredentialValidity(credValidClaim2t2, 50*time.Second)
+	err = verifier.VerifyCredentialValidity(credValidClaim2t2, 500*time.Second)
 	assert.Nil(t, err)
 
 	//
-	// {Ts: 300, BlockN: 14} -> claim1 is revoked
+	// {Ts: 3000, BlockN: 140} -> claim1 is revoked
 	//
-	blockTs, blockN = 300, 14
+	blockTs, blockN = 3000, 140
 
 	// ISSUER: Publish state a third time revoking claim1
 
@@ -308,28 +313,28 @@ func TestVerifyCredentialValidity(t *testing.T) {
 	assert.Nil(t, err)
 
 	// C1T2 with long freshness is valid
-	err = verifier.VerifyCredentialValidity(credValidClaim1t1, 250*time.Second)
+	err = verifier.VerifyCredentialValidity(credValidClaim1t1, 2500*time.Second)
 	assert.Nil(t, err)
 
 	// C2T2 with mid freshness is valid
-	err = verifier.VerifyCredentialValidity(credValidClaim2t2, 150*time.Second)
+	err = verifier.VerifyCredentialValidity(credValidClaim2t2, 1500*time.Second)
 	assert.Nil(t, err)
 
 	// C2T3 with small freshness is valid
-	err = verifier.VerifyCredentialValidity(credValidClaim2t3, 50*time.Second)
+	err = verifier.VerifyCredentialValidity(credValidClaim2t3, 500*time.Second)
 	assert.Nil(t, err)
 
-	// C3T3 has not expired at T=300 (expiration=350)
-	err = verifier.VerifyCredentialValidity(credValidClaim3t3, 1000*time.Second)
+	// C3T3 has not expired at T=3000 (expiration=3500)
+	err = verifier.VerifyCredentialValidity(credValidClaim3t3, 10000*time.Second)
 	assert.Nil(t, err)
 
 	//
-	// {Ts: 400, BlockN: --}
+	// {Ts: 4000, BlockN: --}
 	//
-	blockTs, blockN = 400, 15
+	blockTs, blockN = 4000, 150
 
 	// C3T3 has expired at T=400 (expiration=350)
-	err = verifier.VerifyCredentialValidity(credValidClaim3t3, 1000*time.Second)
+	err = verifier.VerifyCredentialValidity(credValidClaim3t3, 10000*time.Second)
 	assert.Equal(t, ErrClaimExpired, err)
 }
 

--- a/core/proof/proof.go
+++ b/core/proof/proof.go
@@ -3,6 +3,8 @@ package proof
 import (
 
 	// common3 "github.com/iden3/go-iden3-core/common"
+	"fmt"
+
 	"github.com/iden3/go-iden3-core/core"
 	"github.com/iden3/go-iden3-core/merkletree"
 	// "github.com/iden3/go-iden3-crypto/babyjub"
@@ -24,10 +26,20 @@ type CredentialExistence struct {
 	IdenPubUrl          string
 }
 
+func (c CredentialExistence) String() string {
+	type alias CredentialExistence
+	return fmt.Sprintf("%+v", alias(c))
+}
+
 type CredentialValidity struct {
 	CredentialExistence CredentialExistence
 	IdenStateData       IdenStateData
 	MtpNotNonce         *merkletree.Proof
 	ClaimsTreeRoot      *merkletree.Hash
 	RootsTreeRoot       *merkletree.Hash
+}
+
+func (c CredentialValidity) String() string {
+	type alias CredentialValidity
+	return fmt.Sprintf("%+v", alias(c))
 }

--- a/identity/issuer/issuer_test.go
+++ b/identity/issuer/issuer_test.go
@@ -113,6 +113,7 @@ func TestIssuerPublish(t *testing.T) {
 
 	// Sync (finally in the smart contract)
 	idenPubOnChain.Sync()
+	blockN += 10
 	err = issuer.SyncIdenStatePublic()
 	require.Nil(t, err)
 	assert.Equal(t, newState, issuer.idenStateOnChain())
@@ -144,6 +145,7 @@ func TestIssuerPublish(t *testing.T) {
 
 	// Sync (finally in the smart contract)
 	idenPubOnChain.Sync()
+	blockN += 10
 	err = issuer.SyncIdenStatePublic()
 	require.Nil(t, err)
 	assert.Equal(t, newState, issuer.idenStateOnChain())
@@ -169,6 +171,7 @@ func TestIssuerCredential(t *testing.T) {
 	require.Nil(t, err)
 
 	idenPubOnChain.Sync()
+	blockN += 10
 
 	err = issuer.SyncIdenStatePublic()
 	require.Nil(t, err)
@@ -191,8 +194,9 @@ func TestIssuerCredential(t *testing.T) {
 	assert.Equal(t, ErrClaimNotYetInOnChainState, err)
 }
 
+var blockN uint64
+
 func TestMain(m *testing.M) {
-	var blockN uint64
 	idenPubOnChain = idenpubonchainlocal.New(
 		func() time.Time {
 			return time.Now()

--- a/merkletree/merkletree.go
+++ b/merkletree/merkletree.go
@@ -840,11 +840,11 @@ func (p *Proof) UnmarshalJSON(bs []byte) error {
 }
 
 // String outputs a multiline string representation of the Proof.
-func (p *Proof) String() string {
-	buf := bytes.NewBufferString("Proof:\n")
-	fmt.Fprintf(buf, "\texistence: %v\n", p.Existence)
-	fmt.Fprintf(buf, "\tdepth: %v\n", p.depth)
-	fmt.Fprintf(buf, "\tnotempties: ")
+func (p Proof) String() string {
+	buf := bytes.NewBufferString("{")
+	fmt.Fprintf(buf, "Existence: %v, ", p.Existence)
+	fmt.Fprintf(buf, "Depth: %v, ", p.depth)
+	fmt.Fprintf(buf, "NotEmpties: ")
 	for i := uint(0); i < p.depth; i++ {
 		if common.TestBitBigEndian(p.notempties[:], i) {
 			fmt.Fprintf(buf, "1")
@@ -852,21 +852,25 @@ func (p *Proof) String() string {
 			fmt.Fprintf(buf, "0")
 		}
 	}
-	fmt.Fprintf(buf, "\n")
-	fmt.Fprintf(buf, "\tsiblings: ")
+	fmt.Fprintf(buf, ", ")
+	fmt.Fprintf(buf, "Siblings: [")
 	sibIdx := 0
 	for i := uint(0); i < p.depth; i++ {
 		if common.TestBitBigEndian(p.notempties[:], i) {
-			fmt.Fprintf(buf, "%v ", p.Siblings[sibIdx])
+			fmt.Fprintf(buf, "%v", p.Siblings[sibIdx])
 			sibIdx++
 		} else {
-			fmt.Fprintf(buf, "0 ")
+			fmt.Fprintf(buf, "0")
+		}
+		if i < p.depth-1 {
+			fmt.Fprintf(buf, ", ")
 		}
 	}
-	fmt.Fprintf(buf, "\n")
+	fmt.Fprintf(buf, "]")
 	if p.nodeAux != nil {
-		fmt.Fprintf(buf, "\tnode aux: hi: %v, ht: %v\n", p.nodeAux.hIndex, p.nodeAux.hValue)
+		fmt.Fprintf(buf, ", NodeAux: {Hi: %v, Hv: %v}}", p.nodeAux.hIndex, p.nodeAux.hValue)
 	}
+	fmt.Fprintf(buf, "}")
 	return buf.String()
 }
 

--- a/merkletree/merkletree_test.go
+++ b/merkletree/merkletree_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var debug = false
+var debug = true
 
 // If generateTest is true, the checked values will be used to generate a test vector
 var generateTest = false


### PR DESCRIPTION
Resolve #298 
Resolve #345 

In the many tests we have done so far (more than 50 times I would say) we have encountered one particular error twice: where the Issuer calls GetState and gets a result with BlockN and the holder calls GetState and gets the result with BlockN+1.  After some analysis I have concluded that this is an expected behavior of the blockchain: the Issuer may querying the method to a node that ends up in a forked spurious chain in which the state update happens in a different block.  To solve this, GetState must only be called when enough blocks have passed after the transaction that caused the state update, to make sure that the obtained result is final.

This PR checks that the tx of the state update is successful and only syncs the on chain state after the tx has number of confirmation blocks specified in the config.  The default config sets the number of confirmed blocks to 3.