### PR TITLE
swap endianness for schema

### DIFF
--- a/claim.go
+++ b/claim.go
@@ -298,13 +298,13 @@ func NewClaim(schemaHash SchemaHash, options ...Option) (*Claim, error) {
 
 // SetSchemaHash updates claim's schema hash.
 func (c *Claim) SetSchemaHash(schema SchemaHash) {
-	copy(c.index[0][:schemaHashLn], schema[:])
+	copy(c.index[0][:schemaHashLn], utils.SwapEndianness(schema[:]))
 }
 
 // GetSchemaHash return copy of claim's schema hash.
 func (c *Claim) GetSchemaHash() SchemaHash {
 	var schemaHash SchemaHash
-	copy(schemaHash[:], c.index[0][:schemaHashLn])
+	copy(schemaHash[:], utils.SwapEndianness(c.index[0][:schemaHashLn]))
 	return schemaHash
 }
 

--- a/claim_test.go
+++ b/claim_test.go
@@ -2,7 +2,9 @@ package core
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
+	"github.com/iden3/go-iden3-crypto/utils"
 	"math"
 	"math/big"
 	"math/rand"
@@ -71,7 +73,14 @@ func TestClaim_GetSchemaHash(t *testing.T) {
 	require.Equal(t, schemaHashLn, n)
 	claim, err := NewClaim(sc)
 	require.NoError(t, err)
-	require.True(t, bytes.Equal(sc[:], claim.index[0][:schemaHashLn]))
+	require.True(t, bytes.Equal(sc[:], utils.SwapEndianness(claim.index[0][:schemaHashLn])))
+
+	shFromClaim := claim.GetSchemaHash()
+	shFromClaimHexBytes, err := shFromClaim.MarshalText()
+	require.NoError(t, err)
+
+	require.Equal(t, hex.EncodeToString(sc[:]), string(shFromClaimHexBytes))
+
 }
 
 func TestClaim_GetFlagUpdatable(t *testing.T) {


### PR DESCRIPTION
- swap endianness for schema on claim creation
- get schema hash returns unswapped bytes