### PR TITLE
Update README with AGPL license

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ All code here is experimental and WIP
 
 ## License
 go-iden3-core is part of the iden3 project copyright 2018 0kims association
-and published with GPL-3 license, please check the LICENSE file for more details.
+and published with AGPL-3.0 license, please check the LICENSE file for more details.


### PR DESCRIPTION
The README states this is a GPL-3 repository but the GitHub repository and LICENSE file states this is AGPL-3.0.

This PR corrects the README to what I believe is the intended license. It might be best to just direct to LICENSE entirely.